### PR TITLE
Add travis ci/cd

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+repo_token: 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.travis.yml export-ignore
+.coveralls.yml export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+os: linux
 node_js:
   - 10
   - 12
@@ -6,12 +7,61 @@ branches:
   only:
     - master
     - develop
+    - feature/travis-cicd
 cache:
   directories:
     - node_modules
 
-before_script:
-  - yarn add git+https://github.com/reflex-media/lesgo-framework.git#${TRAVIS_BRANCH}
+deploy_service_job: &DEPLOY_SERVICE_JOB
+  stage: deploy
+  cache:
+    directories:
+      - node_modules
+      - ${SERVICE_PATH}/node_modules
 
-script:
-  - yarn coveralls
+  install:
+    - yarn global add serverless
+    - travis_retry yarn install
+    - cd ${SERVICE_PATH}
+    - travis_retry yarn install
+    - cd -
+
+  script:
+    - cd ${SERVICE_PATH}
+    - yarn coveralls || travis_terminate 1;
+    - yarn deploy -y -s ${STAGE_NAME}
+    - cd -
+
+environments:
+  - &PRODUCTION_ENV
+    - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID_PRODUCTION}
+    - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY_PRODUCTION}
+
+  - &DEVELOPMENT_ENV
+    - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID_DEVELOPMENT}
+    - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY_DEVELOPMENT}
+
+jobs:
+  include:
+    - stage: unit tests
+      before_script:
+        - yarn add git+https://github.com/reflex-media/lesgo-lite.git#${TRAVIS_BRANCH}
+
+      script:
+        - yarn coveralls
+    # non-master branches deploys to stage named by the branch
+    - <<: *DEPLOY_SERVICE_JOB
+      name: "Deploy lesgo-lite"
+      if: type = push AND NOT branch = master
+      env:
+        - SERVICE_PATH="services/lesgo-lite"
+        - STAGE_NAME=development
+        - *DEVELOPMENT_ENV
+    # master branch deploys to the 'prod' stage
+    - <<: *DEPLOY_SERVICE_JOB
+      name: "Deploy services/lesgo-lite"
+      if: type = push AND branch = master
+      env:
+        - SERVICE_PATH="services/services/lesgo-lite"
+        - STAGE_NAME=production
+        - *PRODUCTION_ENV


### PR DESCRIPTION
Added required Travis configuration to allow ci/cd pipeline using Travis-ci.
This PR requires an update on Lesgo-framework, which would alter lesgo-scripts to allow for no human interaction during deployment

Note: 

- Requires to add environment on Travis dashboard
-- AWS_ACCESS_KEY_ID_PRODUCTION
-- AWS_SECRET_ACCESS_KEY_PRODUCTION
-- AWS_ACCESS_KEY_ID_DEVELOPMENT
-- AWS_SECRET_ACCESS_KEY_DEVELOPMENT

- Requires to remove, before AWS ACCESS and SECRET can be used.
-- AWS_ACCOUNT_PROFILE